### PR TITLE
Bounds and Geometry fields in model

### DIFF
--- a/query.go
+++ b/query.go
@@ -38,6 +38,16 @@ type overpassResponseElement struct {
 		Ref  int64       `json:"ref"`
 		Role string      `json:"role"`
 	} `json:"members"`
+	Geometry []struct {
+		Lat float64 `json:"lat"`
+		Lon float64 `json:"lon"`
+	} `json:"geometry"`
+	Bounds *struct {
+		MinLat float64 `json:"minlat"`
+		MinLon float64 `json:"minlon"`
+		MaxLat float64 `json:"maxlat"`
+		MaxLon float64 `json:"maxlon"`
+	} `json:"bounds"`
 	Tags map[string]string `json:"tags"`
 }
 
@@ -48,9 +58,12 @@ func (c *Client) Query(query string) (Result, error) {
 		return Result{}, err
 	}
 
+	return unmarshal(body)
+}
+
+func unmarshal(body []byte) (Result, error) {
 	var overpassRes overpassResponse
-	err = json.Unmarshal(body, &overpassRes)
-	if err != nil {
+	if err := json.Unmarshal(body, &overpassRes); err != nil {
 		return Result{}, ErrOverpassError
 	}
 
@@ -83,11 +96,22 @@ func (c *Client) Query(query string) (Result, error) {
 		case ElementTypeWay:
 			way := result.getWay(el.ID)
 			*way = Way{
-				Meta:  meta,
-				Nodes: make([]*Node, len(el.Nodes)),
+				Meta:     meta,
+				Nodes:    make([]*Node, len(el.Nodes)),
+				Geometry: make([]Point, len(el.Geometry)),
 			}
 			for idx, nodeID := range el.Nodes {
 				way.Nodes[idx] = result.getNode(nodeID)
+			}
+			if el.Bounds != nil {
+				way.Bounds.Min.Lat = el.Bounds.MinLat
+				way.Bounds.Min.Lon = el.Bounds.MinLon
+				way.Bounds.Max.Lat = el.Bounds.MaxLat
+				way.Bounds.Max.Lon = el.Bounds.MaxLon
+			}
+			for idx, geo := range el.Geometry {
+				way.Geometry[idx].Lat = geo.Lat
+				way.Geometry[idx].Lon = geo.Lon
 			}
 		case ElementTypeRelation:
 			relation := result.getRelation(el.ID)
@@ -109,6 +133,12 @@ func (c *Client) Query(query string) (Result, error) {
 					relationMember.Relation = result.getRelation(member.Ref)
 				}
 				relation.Members[idx] = relationMember
+			}
+			if el.Bounds != nil {
+				relation.Bounds.Min.Lat = el.Bounds.MinLat
+				relation.Bounds.Min.Lon = el.Bounds.MinLon
+				relation.Bounds.Max.Lat = el.Bounds.MaxLat
+				relation.Bounds.Max.Lon = el.Bounds.MaxLon
 			}
 		}
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,91 @@
+package overpass
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshal(t *testing.T) {
+	testCases := []struct {
+		input string
+		want  Result
+	}{
+		{
+			`{"elements":[{"type":"way","id":1,
+				"bounds":{"minlat":-37.9,"minlon":144.6,"maxlat":-37.8,"maxlon":144.7}
+			}]}`,
+			Result{
+				Count: 1,
+				Ways: map[int64]*Way{1: {
+					Bounds: Box{Min: Point{-37.9, 144.6}, Max: Point{-37.8, 144.7}},
+				}},
+			},
+		},
+		{
+			`{"elements":[{"type":"way","id":1,
+				"geometry":[{"lat":-37.9,"lon":144.6},{"lat":-37.8,"lon":144.7}]
+			}]}`,
+			Result{
+				Count: 1,
+				Ways: map[int64]*Way{1: {
+					Geometry: []Point{{-37.9, 144.6}, {-37.8, 144.7}},
+				}},
+			},
+		},
+		{
+			`{"elements":[{"type":"relation","id":1,
+				"bounds":{"minlat":-37.9,"minlon":144.6,"maxlat":-37.8,"maxlon":144.7}
+			}]}`,
+			Result{
+				Count: 1,
+				Relations: map[int64]*Relation{1: {
+					Bounds: Box{Min: Point{-37.9, 144.6}, Max: Point{-37.8, 144.7}},
+				}},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			got, err := unmarshal([]byte(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.want.Nodes == nil {
+				tc.want.Nodes = map[int64]*Node{}
+			} else {
+				for id, n := range tc.want.Nodes {
+					n.Meta.ID = id
+				}
+			}
+			if tc.want.Ways == nil {
+				tc.want.Ways = map[int64]*Way{}
+			} else {
+				for id, w := range tc.want.Ways {
+					w.Meta.ID = id
+					if w.Nodes == nil {
+						w.Nodes = []*Node{}
+					}
+					if w.Geometry == nil {
+						w.Geometry = []Point{}
+					}
+				}
+			}
+			if tc.want.Relations == nil {
+				tc.want.Relations = map[int64]*Relation{}
+			} else {
+				for id, r := range tc.want.Relations {
+					r.Meta.ID = id
+					if r.Members == nil {
+						r.Members = []RelationMember{}
+					}
+				}
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("%v != %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/types.go
+++ b/types.go
@@ -33,13 +33,24 @@ type Node struct {
 // Way represents OSM way type.
 type Way struct {
 	Meta
-	Nodes []*Node
+	Nodes    []*Node
+	Bounds   Box
+	Geometry []Point
+}
+
+type Point struct {
+	Lat, Lon float64
 }
 
 // Relation represents OSM relation type.
 type Relation struct {
 	Meta
 	Members []RelationMember
+	Bounds  Box
+}
+
+type Box struct {
+	Min, Max Point
 }
 
 // RelationMember represents OSM relation member type.


### PR DESCRIPTION
Adds the two missing `Bounds` and `Geometry` fields that are returned when using the `out geom;` output modifier.
Includes unit tests.