### PR TITLE
Wrap underlying errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,13 +1,20 @@
 package overpass
 
-import "net/http"
+import (
+	"net/http"
+	"net/url"
+)
 
 const apiEndpoint = "https://overpass-api.de/api/interpreter"
+
+type HTTPClient interface {
+	PostForm(url string, data url.Values) (*http.Response, error)
+}
 
 // A Client manages communication with the Overpass API.
 type Client struct {
 	apiEndpoint string
-	httpClient  *http.Client
+	httpClient  HTTPClient
 	semaphore   chan struct{}
 }
 
@@ -20,7 +27,7 @@ func New() Client {
 func NewWithSettings(
 	apiEndpoint string,
 	maxParallel int,
-	httpClient *http.Client,
+	httpClient HTTPClient,
 ) Client {
 	c := Client{
 		apiEndpoint: apiEndpoint,

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,47 @@
+package overpass
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"testing/iotest"
+)
+
+func TestQueryErrors(t *testing.T) {
+	testCases := []struct {
+		res  *http.Response
+		err  error
+		want string
+	}{
+		{nil, errors.New("request fail"), "http error: request fail"},
+		{&http.Response{StatusCode: 400, Body: io.NopCloser(bytes.NewReader(nil))}, nil, "overpass engine error: 400 Bad Request"},
+		{&http.Response{StatusCode: 200, Body: io.NopCloser(iotest.ErrReader(errors.New("read fail")))}, nil, "http error: read fail"},
+		{&http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(nil))}, nil, "overpass engine error: unexpected end of JSON input"},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			cli := NewWithSettings(apiEndpoint, 1, &mockHttpClient{tc.res, tc.err})
+			if _, err := cli.Query(""); err == nil {
+				t.Fatal("unexpected success")
+			} else if err.Error() != tc.want {
+				t.Fatalf("%s != %s", err.Error(), tc.want)
+			} else if err = errors.Unwrap(err); err == nil {
+				t.Fatal("expected wrapped error")
+			}
+		})
+	}
+}
+
+type mockHttpClient struct {
+	res *http.Response
+	err error
+}
+
+func (m *mockHttpClient) PostForm(string, url.Values) (res *http.Response, err error) {
+	return m.res, m.err
+}


### PR DESCRIPTION
Wrap underlying errors so that clients have access to the cause of failures if needed. Debugging problems is really challenging when the actual errors are discarded and all you get is "Overpass engine error".
Includes unit tests.