### PR TITLE
Add OSM XML support

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -26,3 +26,30 @@ func (r *Result) getRelation(id int64) *Relation {
 	}
 	return relation
 }
+
+func (r *Result) getOldNode(id int64) *Node {
+	node, ok := r.OldNodes[id]
+	if !ok {
+		node = &Node{Meta: Meta{ID: id}}
+		r.OldNodes[id] = node
+	}
+	return node
+}
+
+func (r *Result) getOldWay(id int64) *Way {
+	way, ok := r.OldWays[id]
+	if !ok {
+		way = &Way{Meta: Meta{ID: id}}
+		r.OldWays[id] = way
+	}
+	return way
+}
+
+func (r *Result) getOldRelation(id int64) *Relation {
+	relation, ok := r.OldRelations[id]
+	if !ok {
+		relation = &Relation{Meta: Meta{ID: id}}
+		r.OldRelations[id] = relation
+	}
+	return relation
+}

--- a/json.go
+++ b/json.go
@@ -1,0 +1,140 @@
+package overpass
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type overpassJsonResponse struct {
+	OSM3S struct {
+		TimestampOSMBase time.Time `json:"timestamp_osm_base"`
+	} `json:"osm3s"`
+	Elements []overpassJsonResponseElement `json:"elements"`
+}
+
+type overpassJsonResponseElement struct {
+	Type      ElementType `json:"type"`
+	ID        int64       `json:"id"`
+	Lat       float64     `json:"lat"`
+	Lon       float64     `json:"lon"`
+	Timestamp *time.Time  `json:"timestamp"`
+	Version   int64       `json:"version"`
+	Changeset int64       `json:"changeset"`
+	User      string      `json:"user"`
+	UID       int64       `json:"uid"`
+	Nodes     []int64     `json:"nodes"`
+	Members   []struct {
+		Type ElementType `json:"type"`
+		Ref  int64       `json:"ref"`
+		Role string      `json:"role"`
+	} `json:"members"`
+	Geometry []struct {
+		Lat float64 `json:"lat"`
+		Lon float64 `json:"lon"`
+	} `json:"geometry"`
+	Bounds *struct {
+		MinLat float64 `json:"minlat"`
+		MinLon float64 `json:"minlon"`
+		MaxLat float64 `json:"maxlat"`
+		MaxLon float64 `json:"maxlon"`
+	} `json:"bounds"`
+	Tags map[string]string `json:"tags"`
+}
+
+func unmarshalJson(body []byte) (Result, error) {
+	var overpassRes overpassJsonResponse
+	if err := json.Unmarshal(body, &overpassRes); err != nil {
+		return Result{}, fmt.Errorf("overpass engine error: %w", err)
+	}
+
+	result := Result{
+		Timestamp: overpassRes.OSM3S.TimestampOSMBase,
+		Count:     len(overpassRes.Elements),
+		Nodes:     make(map[int64]*Node),
+		Ways:      make(map[int64]*Way),
+		Relations: make(map[int64]*Relation),
+	}
+
+	for _, el := range overpassRes.Elements {
+		meta := Meta{
+			ID:        el.ID,
+			Timestamp: el.Timestamp,
+			Version:   el.Version,
+			Changeset: el.Changeset,
+			User:      el.User,
+			UID:       el.UID,
+			Tags:      el.Tags,
+		}
+		switch el.Type {
+		case ElementTypeNode:
+			node := result.getNode(el.ID)
+			*node = Node{
+				Meta: meta,
+				Lat:  el.Lat,
+				Lon:  el.Lon,
+			}
+		case ElementTypeWay:
+			way := result.getWay(el.ID)
+			*way = Way{
+				Meta:     meta,
+				Nodes:    make([]*Node, len(el.Nodes)),
+				Geometry: make([]Point, len(el.Geometry)),
+			}
+			for idx, nodeID := range el.Nodes {
+				way.Nodes[idx] = result.getNode(nodeID)
+			}
+			if el.Bounds != nil {
+				way.Bounds = &Box{
+					Min: Point{
+						Lat: el.Bounds.MinLat,
+						Lon: el.Bounds.MinLon,
+					},
+					Max: Point{
+						Lat: el.Bounds.MaxLat,
+						Lon: el.Bounds.MaxLon,
+					},
+				}
+			}
+			for idx, geo := range el.Geometry {
+				way.Geometry[idx].Lat = geo.Lat
+				way.Geometry[idx].Lon = geo.Lon
+			}
+		case ElementTypeRelation:
+			relation := result.getRelation(el.ID)
+			*relation = Relation{
+				Meta:    meta,
+				Members: make([]RelationMember, len(el.Members)),
+			}
+			for idx, member := range el.Members {
+				relationMember := RelationMember{
+					Type: member.Type,
+					Role: member.Role,
+				}
+				switch member.Type {
+				case ElementTypeNode:
+					relationMember.Node = result.getNode(member.Ref)
+				case ElementTypeWay:
+					relationMember.Way = result.getWay(member.Ref)
+				case ElementTypeRelation:
+					relationMember.Relation = result.getRelation(member.Ref)
+				}
+				relation.Members[idx] = relationMember
+			}
+			if el.Bounds != nil {
+				relation.Bounds = &Box{
+					Min: Point{
+						Lat: el.Bounds.MinLat,
+						Lon: el.Bounds.MinLon,
+					},
+					Max: Point{
+						Lat: el.Bounds.MaxLat,
+						Lon: el.Bounds.MaxLon,
+					},
+				}
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/query.go
+++ b/query.go
@@ -1,48 +1,21 @@
 package overpass
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"time"
 )
+
+const ApiOutputFormatJson string = "json"
 
 type overpassResponse struct {
 	OSM3S struct {
 		TimestampOSMBase time.Time `json:"timestamp_osm_base"`
 	} `json:"osm3s"`
-	Elements []overpassResponseElement `json:"elements"`
-}
-
-type overpassResponseElement struct {
-	Type      ElementType `json:"type"`
-	ID        int64       `json:"id"`
-	Lat       float64     `json:"lat"`
-	Lon       float64     `json:"lon"`
-	Timestamp *time.Time  `json:"timestamp"`
-	Version   int64       `json:"version"`
-	Changeset int64       `json:"changeset"`
-	User      string      `json:"user"`
-	UID       int64       `json:"uid"`
-	Nodes     []int64     `json:"nodes"`
-	Members   []struct {
-		Type ElementType `json:"type"`
-		Ref  int64       `json:"ref"`
-		Role string      `json:"role"`
-	} `json:"members"`
-	Geometry []struct {
-		Lat float64 `json:"lat"`
-		Lon float64 `json:"lon"`
-	} `json:"geometry"`
-	Bounds *struct {
-		MinLat float64 `json:"minlat"`
-		MinLon float64 `json:"minlon"`
-		MaxLat float64 `json:"maxlat"`
-		MaxLon float64 `json:"maxlon"`
-	} `json:"bounds"`
-	Tags map[string]string `json:"tags"`
+	Elements []overpassJsonResponse `json:"elements"`
 }
 
 // Query send request to OverpassAPI with provided querystring.
@@ -52,104 +25,11 @@ func (c *Client) Query(query string) (Result, error) {
 		return Result{}, err
 	}
 
-	return unmarshal(body)
-}
-
-func unmarshal(body []byte) (Result, error) {
-	var overpassRes overpassResponse
-	if err := json.Unmarshal(body, &overpassRes); err != nil {
-		return Result{}, fmt.Errorf("overpass engine error: %w", err)
+	outF := getOutputFormatFromQuery(query)
+	if outF == ApiOutputFormatJson {
+		return unmarshalJson(body)
 	}
-
-	result := Result{
-		Timestamp: overpassRes.OSM3S.TimestampOSMBase,
-		Count:     len(overpassRes.Elements),
-		Nodes:     make(map[int64]*Node),
-		Ways:      make(map[int64]*Way),
-		Relations: make(map[int64]*Relation),
-	}
-
-	for _, el := range overpassRes.Elements {
-		meta := Meta{
-			ID:        el.ID,
-			Timestamp: el.Timestamp,
-			Version:   el.Version,
-			Changeset: el.Changeset,
-			User:      el.User,
-			UID:       el.UID,
-			Tags:      el.Tags,
-		}
-		switch el.Type {
-		case ElementTypeNode:
-			node := result.getNode(el.ID)
-			*node = Node{
-				Meta: meta,
-				Lat:  el.Lat,
-				Lon:  el.Lon,
-			}
-		case ElementTypeWay:
-			way := result.getWay(el.ID)
-			*way = Way{
-				Meta:     meta,
-				Nodes:    make([]*Node, len(el.Nodes)),
-				Geometry: make([]Point, len(el.Geometry)),
-			}
-			for idx, nodeID := range el.Nodes {
-				way.Nodes[idx] = result.getNode(nodeID)
-			}
-			if el.Bounds != nil {
-				way.Bounds = &Box{
-					Min: Point{
-						Lat: el.Bounds.MinLat,
-						Lon: el.Bounds.MinLon,
-					},
-					Max: Point{
-						Lat: el.Bounds.MaxLat,
-						Lon: el.Bounds.MaxLon,
-					},
-				}
-			}
-			for idx, geo := range el.Geometry {
-				way.Geometry[idx].Lat = geo.Lat
-				way.Geometry[idx].Lon = geo.Lon
-			}
-		case ElementTypeRelation:
-			relation := result.getRelation(el.ID)
-			*relation = Relation{
-				Meta:    meta,
-				Members: make([]RelationMember, len(el.Members)),
-			}
-			for idx, member := range el.Members {
-				relationMember := RelationMember{
-					Type: member.Type,
-					Role: member.Role,
-				}
-				switch member.Type {
-				case ElementTypeNode:
-					relationMember.Node = result.getNode(member.Ref)
-				case ElementTypeWay:
-					relationMember.Way = result.getWay(member.Ref)
-				case ElementTypeRelation:
-					relationMember.Relation = result.getRelation(member.Ref)
-				}
-				relation.Members[idx] = relationMember
-			}
-			if el.Bounds != nil {
-				relation.Bounds = &Box{
-					Min: Point{
-						Lat: el.Bounds.MinLat,
-						Lon: el.Bounds.MinLon,
-					},
-					Max: Point{
-						Lat: el.Bounds.MaxLat,
-						Lon: el.Bounds.MaxLon,
-					},
-				}
-			}
-		}
-	}
-
-	return result, nil
+	return unmarshalXml(body)
 }
 
 func (c *Client) httpPost(query string) ([]byte, error) {
@@ -189,4 +69,13 @@ type ServerError struct {
 
 func (e *ServerError) Error() string {
 	return fmt.Sprintf("%d %s", e.StatusCode, http.StatusText(e.StatusCode))
+}
+
+func getOutputFormatFromQuery(query string) string {
+	re := regexp.MustCompile("\\[out:([a-z]+)]")
+	match := re.FindStringSubmatch(query)
+	if len(match) == 2 {
+		return match[1]
+	}
+	return ""
 }

--- a/query_test.go
+++ b/query_test.go
@@ -12,7 +12,87 @@ import (
 	"testing/iotest"
 )
 
-func TestUnmarshal(t *testing.T) {
+func TestUnmarshalXml(t *testing.T) {
+	testCases := []struct {
+		input string
+		want  Result
+	}{
+		{
+			`<osm><way id="1"><bounds minlat="-37.9" minlon="144.6" maxlat="-37.8" maxlon="144.7" /></way></osm>`,
+			Result{
+				Count: 1,
+				Ways: map[int64]*Way{1: {
+					Bounds: &Box{Min: Point{-37.9, 144.6}, Max: Point{-37.8, 144.7}},
+				}},
+			},
+		},
+		{
+			`<osm><way id="1"><nd ref="1" lat="-37.9" lon="144.6" /><nd ref="2" lat="-37.8" lon="144.7" /></way></osm>`,
+			Result{
+				Count: 1,
+				Nodes: map[int64]*Node{1: {Meta: Meta{ID: 1}}, 2: {Meta: Meta{ID: 2}}},
+				Ways: map[int64]*Way{1: {
+					Nodes:    []*Node{{Meta: Meta{ID: 1}}, {Meta: Meta{ID: 2}}},
+					Geometry: []Point{{-37.9, 144.6}, {-37.8, 144.7}},
+				}},
+			},
+		},
+		{
+			`<osm><relation id="1"><bounds minlat="-37.9" minlon="144.6" maxlat="-37.8" maxlon="144.7"/></relation></osm>`,
+			Result{
+				Count: 1,
+				Relations: map[int64]*Relation{1: {
+					Bounds: &Box{Min: Point{-37.9, 144.6}, Max: Point{-37.8, 144.7}},
+				}},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			got, err := unmarshalXml([]byte(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.want.Nodes == nil {
+				tc.want.Nodes = map[int64]*Node{}
+			} else {
+				for id, n := range tc.want.Nodes {
+					n.Meta.ID = id
+				}
+			}
+			if tc.want.Ways == nil {
+				tc.want.Ways = map[int64]*Way{}
+			} else {
+				for id, w := range tc.want.Ways {
+					w.Meta.ID = id
+					if w.Nodes == nil {
+						w.Nodes = []*Node{}
+					}
+					if w.Geometry == nil {
+						w.Geometry = []Point{}
+					}
+				}
+			}
+			if tc.want.Relations == nil {
+				tc.want.Relations = map[int64]*Relation{}
+			} else {
+				for id, r := range tc.want.Relations {
+					r.Meta.ID = id
+					if r.Members == nil {
+						r.Members = []RelationMember{}
+					}
+				}
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("%v != %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshalJson(t *testing.T) {
 	testCases := []struct {
 		input string
 		want  Result
@@ -24,7 +104,7 @@ func TestUnmarshal(t *testing.T) {
 			Result{
 				Count: 1,
 				Ways: map[int64]*Way{1: {
-					Bounds: Box{Min: Point{-37.9, 144.6}, Max: Point{-37.8, 144.7}},
+					Bounds: &Box{Min: Point{-37.9, 144.6}, Max: Point{-37.8, 144.7}},
 				}},
 			},
 		},
@@ -46,7 +126,7 @@ func TestUnmarshal(t *testing.T) {
 			Result{
 				Count: 1,
 				Relations: map[int64]*Relation{1: {
-					Bounds: Box{Min: Point{-37.9, 144.6}, Max: Point{-37.8, 144.7}},
+					Bounds: &Box{Min: Point{-37.9, 144.6}, Max: Point{-37.8, 144.7}},
 				}},
 			},
 		},
@@ -54,7 +134,7 @@ func TestUnmarshal(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
-			got, err := unmarshal([]byte(tc.input))
+			got, err := unmarshalJson([]byte(tc.input))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -105,7 +185,7 @@ func TestQueryErrors(t *testing.T) {
 		{nil, errors.New("request fail"), "http error: request fail"},
 		{&http.Response{StatusCode: 400, Body: io.NopCloser(bytes.NewReader(nil))}, nil, "overpass engine error: 400 Bad Request"},
 		{&http.Response{StatusCode: 200, Body: io.NopCloser(iotest.ErrReader(errors.New("read fail")))}, nil, "http error: read fail"},
-		{&http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(nil))}, nil, "overpass engine error: unexpected end of JSON input"},
+		{&http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(nil))}, nil, "overpass engine error: EOF"},
 	}
 
 	for i, tc := range testCases {

--- a/types.go
+++ b/types.go
@@ -20,6 +20,7 @@ type Meta struct {
 	Changeset int64
 	User      string
 	UID       int64
+	Visible   *bool
 	Tags      map[string]string
 }
 
@@ -62,11 +63,35 @@ type RelationMember struct {
 	Role     string
 }
 
-// Result returned by Query and contains parsed result of Overpass query.
-type Result struct {
-	Timestamp time.Time
-	Count     int
+type Create struct {
 	Nodes     map[int64]*Node
 	Ways      map[int64]*Way
 	Relations map[int64]*Relation
+}
+
+type Modify struct {
+	Nodes     map[int64]map[string]*Node
+	Ways      map[int64]map[string]*Way
+	Relations map[int64]map[string]*Relation
+}
+
+type Delete struct {
+	Nodes     map[int64]*Node
+	Ways      map[int64]*Way
+	Relations map[int64]*Relation
+}
+
+// Result returned by Query and contains parsed result of Overpass query.
+type Result struct {
+	Timestamp    time.Time
+	Count        int
+	Nodes        map[int64]*Node
+	Ways         map[int64]*Way
+	Relations    map[int64]*Relation
+	OldNodes     map[int64]*Node
+	OldWays      map[int64]*Way
+	OldRelations map[int64]*Relation
+	Create       *Create
+	Modify       *Modify
+	Delete       *Delete
 }

--- a/xml.go
+++ b/xml.go
@@ -1,0 +1,354 @@
+package overpass
+
+import (
+	"encoding/xml"
+	"fmt"
+	"time"
+)
+
+type ActionType string
+
+const (
+	ActionTypeCreate ActionType = "create"
+	ActionTypeModify ActionType = "modify"
+	ActionTypeDelete ActionType = "delete"
+)
+
+type Attributes struct {
+	ID        int64      `xml:"id,attr"`
+	Timestamp *time.Time `xml:"timestamp,attr"`
+	Version   int64      `xml:"version,attr"`
+	Changeset int64      `xml:"changeset,attr"`
+	User      string     `xml:"user,attr"`
+	UID       int64      `xml:"uid,attr"`
+	Visible   bool       `xml:"visible,attr"`
+	Tags      []Tag      `xml:"tag"`
+}
+
+type Tag struct {
+	K string `xml:"k,attr"`
+	V string `xml:"v,attr"`
+}
+
+type NodeXml struct {
+	Attributes
+	Lat float64 `xml:"lat,attr"`
+	Lon float64 `xml:"lon,attr"`
+}
+
+type WayXml struct {
+	Attributes
+	Bounds *Bounds `xml:"bounds"`
+	Nodes  []*struct {
+		Ref int64   `xml:"ref,attr"`
+		Lat float64 `xml:"lat,attr"`
+		Lon float64 `xml:"lon,attr"`
+	} `xml:"nd"`
+}
+
+type RelationXml struct {
+	Attributes
+	Bounds  *Bounds `xml:"bounds"`
+	Members []struct {
+		Type ElementType `xml:"type,attr"`
+		Ref  int64       `xml:"ref,attr"`
+		Role string      `xml:"role,attr"`
+	} `xml:"member"`
+}
+
+type Bounds struct {
+	MinLat float64 `xml:"minlat,attr"`
+	MinLon float64 `xml:"minlon,attr"`
+	MaxLat float64 `xml:"maxlat,attr"`
+	MaxLon float64 `xml:"maxlon,attr"`
+}
+
+type Element struct {
+	Node     *NodeXml     `xml:"node"`
+	Way      *WayXml      `xml:"way"`
+	Relation *RelationXml `xml:"relation"`
+}
+
+type overpassXmlResponse struct {
+	Version   string `xml:"version,attr"`
+	Generator string `xml:"generator,attr"`
+	Note      string `xml:"note"`
+	Meta      struct {
+		OsmBase time.Time  `xml:"osm_base,attr"`
+		Areas   *time.Time `xml:"areas,attr"`
+	} `xml:"meta"`
+	Bounds    *Bounds        `xml:"bounds"`
+	Nodes     []*NodeXml     `xml:"node"`
+	Ways      []*WayXml      `xml:"way"`
+	Relations []*RelationXml `xml:"relation"`
+	Actions   []*struct {
+		Type     ActionType   `xml:"type,attr"`
+		Old      *Element     `xml:"old"`
+		New      *Element     `xml:"new"`
+		Node     *NodeXml     `xml:"node"`
+		Way      *WayXml      `xml:"way"`
+		Relation *RelationXml `xml:"relation"`
+	} `xml:"action"`
+}
+
+func unmarshalXml(body []byte) (Result, error) {
+	var overpassRes overpassXmlResponse
+	if err := xml.Unmarshal(body, &overpassRes); err != nil {
+		return Result{}, fmt.Errorf("overpass engine error: %w", err)
+	}
+
+	result := Result{
+		Timestamp: overpassRes.Meta.OsmBase,
+		Nodes:     make(map[int64]*Node),
+		Ways:      make(map[int64]*Way),
+		Relations: make(map[int64]*Relation),
+	}
+
+	if overpassRes.Actions == nil {
+		result.Count = len(overpassRes.Nodes) + len(overpassRes.Ways) + len(overpassRes.Relations)
+		for _, el := range overpassRes.Nodes {
+			node := result.getNode(el.ID)
+			result.processNode(el, node)
+		}
+
+		for _, el := range overpassRes.Ways {
+			way := result.getWay(el.ID)
+			result.processWay(el, way)
+		}
+
+		for _, el := range overpassRes.Relations {
+			relation := result.getRelation(el.ID)
+			result.processRelation(el, relation)
+		}
+	} else {
+		result.Count = len(overpassRes.Actions)
+		result.OldNodes = make(map[int64]*Node)
+		result.OldWays = make(map[int64]*Way)
+		result.OldRelations = make(map[int64]*Relation)
+		for _, el := range overpassRes.Actions {
+			switch el.Type {
+			case ActionTypeCreate:
+				if result.Create == nil {
+					result.Create = &Create{}
+				}
+				if el.Node != nil {
+					node := result.getNode(el.Node.ID)
+					result.processNode(el.Node, node)
+					if result.Create.Nodes == nil {
+						result.Create.Nodes = make(map[int64]*Node)
+					}
+					result.Create.Nodes[el.Node.ID] = node
+				}
+				if el.Way != nil {
+					way := result.getWay(el.Way.ID)
+					result.processWay(el.Way, way)
+					if result.Create.Ways == nil {
+						result.Create.Ways = make(map[int64]*Way)
+					}
+					result.Create.Ways[el.Way.ID] = way
+				}
+				if el.Relation != nil {
+					relation := result.getRelation(el.Relation.ID)
+					result.processRelation(el.Relation, relation)
+					if result.Create.Relations == nil {
+						result.Create.Relations = make(map[int64]*Relation)
+					}
+					result.Create.Relations[el.Relation.ID] = relation
+				}
+
+			case ActionTypeModify:
+				if result.Modify == nil {
+					result.Modify = &Modify{}
+				}
+				if el.Old.Node != nil {
+					node := result.getOldNode(el.Old.Node.ID)
+					result.processNode(el.Old.Node, node)
+					if result.Modify.Nodes == nil {
+						result.Modify.Nodes = make(map[int64]map[string]*Node)
+					}
+					result.Modify.Nodes[el.Old.Node.ID] = map[string]*Node{"old": node}
+				}
+				if el.New.Node != nil {
+					node := result.getNode(el.New.Node.ID)
+					result.processNode(el.New.Node, node)
+					result.Modify.Nodes[el.New.Node.ID]["new"] = node
+				}
+				if el.Old.Way != nil {
+					way := result.getOldWay(el.Old.Way.ID)
+					result.processWay(el.Old.Way, way)
+					if result.Modify.Ways == nil {
+						result.Modify.Ways = make(map[int64]map[string]*Way)
+					}
+					result.Modify.Ways[el.Old.Way.ID] = map[string]*Way{"old": way}
+				}
+				if el.New.Way != nil {
+					way := result.getWay(el.New.Way.ID)
+					result.processWay(el.New.Way, way)
+					result.Modify.Ways[el.New.Way.ID]["new"] = way
+				}
+				if el.Old.Relation != nil {
+					relation := result.getOldRelation(el.Old.Relation.ID)
+					result.processRelation(el.Old.Relation, relation)
+					if result.Modify.Relations == nil {
+						result.Modify.Relations = make(map[int64]map[string]*Relation)
+					}
+					result.Modify.Relations[el.Old.Relation.ID] = map[string]*Relation{"old": relation}
+				}
+				if el.New.Relation != nil {
+					relation := result.getRelation(el.New.Relation.ID)
+					result.processRelation(el.New.Relation, relation)
+					result.Modify.Relations[el.Old.Relation.ID]["new"] = relation
+				}
+
+			case ActionTypeDelete:
+				if result.Delete == nil {
+					result.Delete = &Delete{}
+				}
+				if el.Old.Node != nil {
+					node := result.getOldNode(el.Old.Node.ID)
+					result.processNode(el.Old.Node, node)
+					if result.Delete.Nodes == nil {
+						result.Delete.Nodes = make(map[int64]*Node)
+					}
+					result.Delete.Nodes[el.Old.Node.ID] = node
+				}
+				if el.New != nil && el.New.Node != nil {
+					result.Delete.Nodes[el.New.Node.ID].Visible = &el.New.Node.Visible
+				}
+				if el.Old.Way != nil {
+					way := result.getOldWay(el.Old.Way.ID)
+					result.processWay(el.Old.Way, way)
+					if result.Delete.Ways == nil {
+						result.Delete.Ways = make(map[int64]*Way)
+					}
+					result.Delete.Ways[el.Old.Way.ID] = way
+				}
+				if el.New != nil && el.New.Way != nil {
+					result.Delete.Ways[el.New.Way.ID].Visible = &el.New.Way.Visible
+				}
+				if el.Old.Relation != nil {
+					relation := result.getOldRelation(el.Old.Relation.ID)
+					result.processRelation(el.Old.Relation, relation)
+					if result.Delete.Relations == nil {
+						result.Delete.Relations = make(map[int64]*Relation)
+					}
+					result.Delete.Relations[el.Old.Relation.ID] = relation
+				}
+				if el.New != nil && el.New.Relation != nil {
+					result.Delete.Relations[el.New.Relation.ID].Visible = &el.New.Relation.Visible
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (r *Result) processNode(el *NodeXml, node *Node) {
+	meta := Meta{
+		ID:        el.ID,
+		Timestamp: el.Timestamp,
+		Version:   el.Version,
+		Changeset: el.Changeset,
+		User:      el.User,
+		UID:       el.UID,
+	}
+	*node = Node{
+		Meta: meta,
+		Lat:  el.Lat,
+		Lon:  el.Lon,
+	}
+	if len(el.Tags) > 0 {
+		node.Meta.Tags = make(map[string]string)
+	}
+	for _, tag := range el.Tags {
+		node.Meta.Tags[tag.K] = tag.V
+	}
+}
+
+func (r *Result) processWay(el *WayXml, way *Way) {
+	meta := Meta{
+		ID:        el.ID,
+		Timestamp: el.Timestamp,
+		Version:   el.Version,
+		Changeset: el.Changeset,
+		User:      el.User,
+		UID:       el.UID,
+	}
+	*way = Way{
+		Meta:     meta,
+		Nodes:    make([]*Node, len(el.Nodes)),
+		Geometry: make([]Point, len(el.Nodes)),
+	}
+	for idx, n := range el.Nodes {
+		way.Nodes[idx] = r.getNode(n.Ref)
+		way.Geometry[idx].Lat = n.Lat
+		way.Geometry[idx].Lon = n.Lon
+	}
+	if el.Bounds != nil {
+		way.Bounds = &Box{
+			Min: Point{
+				Lat: el.Bounds.MinLat,
+				Lon: el.Bounds.MinLon,
+			},
+			Max: Point{
+				Lat: el.Bounds.MaxLat,
+				Lon: el.Bounds.MaxLon,
+			},
+		}
+	}
+	if len(el.Tags) > 0 {
+		way.Meta.Tags = make(map[string]string)
+	}
+	for _, tag := range el.Tags {
+		way.Meta.Tags[tag.K] = tag.V
+	}
+}
+
+func (r *Result) processRelation(el *RelationXml, relation *Relation) {
+	meta := Meta{
+		ID:        el.ID,
+		Timestamp: el.Timestamp,
+		Version:   el.Version,
+		Changeset: el.Changeset,
+		User:      el.User,
+		UID:       el.UID,
+	}
+	*relation = Relation{
+		Meta:    meta,
+		Members: make([]RelationMember, len(el.Members)),
+	}
+	for idx, member := range el.Members {
+		relationMember := RelationMember{
+			Type: member.Type,
+			Role: member.Role,
+		}
+		switch member.Type {
+		case ElementTypeNode:
+			relationMember.Node = r.getNode(member.Ref)
+		case ElementTypeWay:
+			relationMember.Way = r.getWay(member.Ref)
+		case ElementTypeRelation:
+			relationMember.Relation = r.getRelation(member.Ref)
+		}
+		relation.Members[idx] = relationMember
+	}
+	if el.Bounds != nil {
+		relation.Bounds = &Box{
+			Min: Point{
+				Lat: el.Bounds.MinLat,
+				Lon: el.Bounds.MinLon,
+			},
+			Max: Point{
+				Lat: el.Bounds.MaxLat,
+				Lon: el.Bounds.MaxLon,
+			},
+		}
+	}
+	if len(el.Tags) > 0 {
+		relation.Meta.Tags = make(map[string]string)
+	}
+	for _, tag := range el.Tags {
+		relation.Meta.Tags[tag.K] = tag.V
+	}
+}


### PR DESCRIPTION
Add support for [OSM XML format](https://wiki.openstreetmap.org/wiki/OSM_XML)  and related [Diff functionality](https://wiki.openstreetmap.org/wiki/Overpass_API/Augmented_Diffs)

Given the distinct structures of regular XML output and the Diff XML format, the' Result' struct has been extended to support Diff data.

Now, go-overpass expects XML format by default to comply with the [Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#Output_format_(out:))

Your review and feedback are greatly appreciated.